### PR TITLE
acu95614 - Add a helper to chk if conn is initialized

### DIFF
--- a/lib/right_amqp/amqp.rb
+++ b/lib/right_amqp/amqp.rb
@@ -112,4 +112,8 @@ module AMQP
       yield
     end
   end
+
+  def self.connected?
+    !!@conn
+  end
 end


### PR DESCRIPTION
GatewayDaemon uses start and stop to initialize and
teardown AMQP connections. Call back block during
stop does not get invoked if connection object
is not yet initialized. A helper in AMQP to
verify the connection status will help
to the gateway to act based on connection object
